### PR TITLE
Load bot token from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,13 @@
 
 ## Настройка `BOT_TOKEN`
 
-В файле `config.py` находится переменная `BOT_TOKEN`. Замените её значение на токен вашего бота, полученный у [BotFather](https://t.me/BotFather). Пример содержимого файла:
+Перед запуском необходимо задать переменную окружения `BOT_TOKEN` со значением токена вашего бота, полученным у [BotFather](https://t.me/BotFather). Пример для Linux/macOS:
 
-```python
-# config.py
-BOT_TOKEN = "Ваш_Telegram_токен"
-
-SUPPORT_CONTACTS = [
-    "@white_listed",
-    "@blacklist3d3",
-    "@Desync_tech",
-]
+```bash
+export BOT_TOKEN="Ваш_Telegram_токен"
 ```
+
+Список контактов службы поддержки оставьте в файле `config.py`.
 
 ## Запуск
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 # config.py
-BOT_TOKEN = "7361354807:AAET8MuxIFqjyqXS_zeSmFnVU0k0hzrIYmo"
 
 SUPPORT_CONTACTS = [
     "@white_listed",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,14 @@
+import os
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import Application, CommandHandler, CallbackQueryHandler, ContextTypes
-from config import BOT_TOKEN as TOKEN, SUPPORT_CONTACTS
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+)
+
+from config import SUPPORT_CONTACTS
 from translations import translations
 from games import games
 from language import ask_language, handle_language_selection, user_languages
@@ -148,7 +155,11 @@ async def change_language(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await query.message.reply_text(translations["start"]["en"], reply_markup=ask_language())
 
 def main():
-    app = Application.builder().token(TOKEN).build()
+    token = os.getenv("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN environment variable is not set")
+
+    app = Application.builder().token(token).build()
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CallbackQueryHandler(partial(handle_language_selection, show_main_menu_fn=show_main_menu), pattern="^lang_"))
     app.add_handler(CallbackQueryHandler(menu_handler, pattern="^menu_"))


### PR DESCRIPTION
## Summary
- remove hardcoded `BOT_TOKEN` from config
- read token from the `BOT_TOKEN` environment variable at startup
- update README with new setup instructions

## Testing
- `flake8` *(fails: E302, E501, F841, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688938282ae48323b10d1b2f7f9a32cd