### PR TITLE
Update purchase links and rename menu options

### DIFF
--- a/games.py
+++ b/games.py
@@ -10,12 +10,12 @@ games = {
             "tr": "🎯 Gerçekçi silah mekaniği ile battle royale.",
             "ja": "🎯 リアルな銃撃戦のバトルロイヤルゲーム。"
         },
-        "guide": "https://example.com/pubg-guide",
+        "guide": "https://docs.google.com/document/d/1wKudPSVOK5TG58Ssv16LPPTup1-Ag_h8eDcR7r8zMsg/edit?tab=t.0#heading=h.ijrhw6dpoj89",
         "links": {
-            "1": "https://pay.example.com/pubg/1",
-            "7": "https://pay.example.com/pubg/7",
-            "15": "https://pay.example.com/pubg/15",
-            "30": "https://pay.example.com/pubg/30"
+            "1": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2653160&lang=ru-RU",
+            "7": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2653191&lang=ru-RU",
+            "15": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2653193&lang=ru-RU",
+            "30": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2653196&lang=ru-RU"
         },
         "durations": ["1", "7", "15", "30"]
     }

--- a/main.py
+++ b/main.py
@@ -60,7 +60,10 @@ async def game_selected(update: Update, context: ContextTypes.DEFAULT_TYPE):
     gid = query.data.split("_")[1]
     user_game_selection[uid] = gid
     game = games[gid]
-    keyboard = [[InlineKeyboardButton(f"{d} days", callback_data=f"sub_{d}")] for d in game["durations"]]
+    keyboard = []
+    for d in game["durations"]:
+        label = f"{d} day" if d == "1" else f"{d} days"
+        keyboard.append([InlineKeyboardButton(label, callback_data=f"sub_{d}")])
     keyboard.append([InlineKeyboardButton(translations["menu_instruction"][lang], callback_data="guide")])
     keyboard.append([InlineKeyboardButton(translations["back"][lang], callback_data="back_to_main")])
     await query.edit_message_text(translations["choose_subscription"][lang], reply_markup=InlineKeyboardMarkup(keyboard))

--- a/translations.py
+++ b/translations.py
@@ -17,12 +17,12 @@ translations = {
         "ja": "✅ 言語は日本語に設定されました。"
     },
     "choose_game": {
-        "en": "🎮 Choose a game:",
-        "ru": "🎮 Выберите игру:",
-        "zh": "🎮 选择一个游戏：",
-        "ko": "🎮 게임을 선택하세요:",
-        "tr": "🎮 Bir oyun seçin:",
-        "ja": "🎮 ゲームを選んでください："
+        "en": "🎮 Choose a product:",
+        "ru": "🎮 Выберите продукт:",
+        "zh": "🎮 选择一个产品：",
+        "ko": "🎮 제품을 선택하세요:",
+        "tr": "🎮 Bir ürün seçin:",
+        "ja": "🎮 製品を選んでください："
     },
     "choose_subscription": {
         "en": "⏳ Choose subscription duration:",
@@ -97,12 +97,12 @@ translations = {
         "ja": "🌐 ウェブサイト"
     },
     "menu_game": {
-        "en": "🎮 Choose game",
-        "ru": "🎮 Выбрать игру",
-        "zh": "🎮 选择游戏",
-        "ko": "🎮 게임 선택",
-        "tr": "🎮 Oyun seç",
-        "ja": "🎮 ゲームを選択"
+        "en": "🎮 Choose product",
+        "ru": "🎮 Выбрать продукт",
+        "zh": "🎮 选择产品",
+        "ko": "🎮 제품 선택",
+        "tr": "🎮 Ürün seç",
+        "ja": "🎮 製品を選択"
     },
     "menu_loader": {
         "en": "⬇️ Download loader",


### PR DESCRIPTION
## Summary
- rename "Choose game" buttons to "Choose product" in translations
- adjust subscription menu to show **1 day** for a single-day option
- update product links and guide URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895034cef48323866e88b47d29f14e