### PR TITLE
Add Escape from Tarkov Arena product

### DIFF
--- a/games.py
+++ b/games.py
@@ -18,5 +18,23 @@ games = {
             "30": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2653196&lang=ru-RU"
         },
         "durations": ["1", "7", "15", "30"]
+    },
+    "tarkov": {
+        "title": "Escape from Tarkov + Arena",
+        "description": {
+            "en": "🎯 Hardcore extraction shooter with Arena mode.",
+            "ru": "🎯 Хардкорный шутер с режимом \"Арена\".",
+            "zh": "🎯 硬核撤离射击并含竞技场模式。",
+            "ko": "🎯 하드코어 추출 슈터와 아레나 모드.",
+            "tr": "🎯 Arena modlu hardcore extraction shooter.",
+            "ja": "🎯 ハードコア脱出シューターとアリーナモード。"
+        },
+        "guide": "https://docs.google.com/document/d/18R7nkxCIMkbPVAsqft_G2EXiSs-ai3alh7r-lMS79K8/edit?tab=t.0#heading=h.ijrhw6dpoj89",
+        "links": {
+            "1": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2775543&lang=ru-RU",
+            "15": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2774554&lang=ru-RU",
+            "30": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2774559&lang=ru-RU"
+        },
+        "durations": ["1", "15", "30"]
     }
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,3 +39,9 @@ def test_loader_password_contains_url():
     for lang in ('en', 'ru', 'zh', 'ko', 'tr', 'ja'):
         text = main.translations['loader_password'][lang].format(url=main.LOADER_URL)
         assert main.LOADER_URL in text
+
+
+def test_tarkov_in_games():
+    assert 'tarkov' in main.games
+    game = main.games['tarkov']
+    assert game['durations'] == ['1', '15', '30']


### PR DESCRIPTION
## Summary
- offer Escape from Tarkov + Arena in the product list
- test that the new product is registered

## Testing
- `flake8` *(fails: E501 and other pre-existing warnings)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688952089ff483238ee72b64ec5b7def