### PR TITLE
Fix Markdown parsing for guide URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ async def guide_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     lang = get_lang(uid)
     gid = user_game_selection.get(uid)
     url = games[gid]["guide"]
-    text = f"{translations['menu_instruction'][lang]}\n{url}"
+    text = f"{translations['menu_instruction'][lang]}\n{escape_markdown(url)}"
     await query.edit_message_text(text, parse_mode="Markdown", reply_markup=back_to_main_button(lang))
 
 async def send_loader_info(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary
- escape underscores in guide links to fix message editing errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889536eb1c08323a9314e1fe4f65a72