### PR TITLE
Add HWID Spoofer product

### DIFF
--- a/games.py
+++ b/games.py
@@ -36,5 +36,22 @@ games = {
             "30": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=2774559&lang=ru-RU"
         },
         "durations": ["1", "15", "30"]
+    },
+    "spoofer": {
+        "title": "HWID Spoofer",
+        "description": {
+            "en": "🔒 Spoofs hardware IDs to bypass bans.",
+            "ru": "🔒 Подменяет HWID для обхода банов.",
+            "zh": "🔒 伪装硬件ID以绕过封禁。",
+            "ko": "🔒 HWID를 변경해 차단을 우회합니다.",
+            "tr": "🔒 Donanım kimliğini sahteleyerek banları aşar.",
+            "ja": "🔒 HWID を変更してBANを回避します。"
+        },
+        "guide": "https://docs.google.com/document/d/1TSe5plI4SNbHSsmscvvwxCaJ-QOzE42jcYchOo4jO7I/edit?tab=t.0#heading=h.ijrhw6dpoj89",
+        "links": {
+            "7": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=3077144&lang=ru-RU",
+            "30": "https://www.digiseller.market/asp2/pay_wm.asp?id_d=3077145&lang=ru-RU"
+        },
+        "durations": ["7", "30"]
     }
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,3 +45,9 @@ def test_tarkov_in_games():
     assert 'tarkov' in main.games
     game = main.games['tarkov']
     assert game['durations'] == ['1', '15', '30']
+
+
+def test_spoofer_in_games():
+    assert 'spoofer' in main.games
+    game = main.games['spoofer']
+    assert game['durations'] == ['7', '30']


### PR DESCRIPTION
## Summary
- add HWID Spoofer to `games` data
- extend tests to cover new product

## Testing
- `pytest -q`
- `flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68895a6ebddc83239aa50c140539efe9