### PR TITLE
Add localized day labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,13 @@ def escape_markdown(text: str) -> str:
     """Escape characters that have special meaning in Markdown."""
     return text.replace("_", "\\_")
 
+
+def duration_label(days: str, lang: str) -> str:
+    """Return label for subscription duration in the given language."""
+    key = "day" if days == "1" else "days"
+    word = translations[key][lang]
+    return f"{days} {word}"
+
 def get_lang(user_id):
     return user_languages.get(user_id, "en")
 
@@ -62,7 +69,7 @@ async def game_selected(update: Update, context: ContextTypes.DEFAULT_TYPE):
     game = games[gid]
     keyboard = []
     for d in game["durations"]:
-        label = f"{d} day" if d == "1" else f"{d} days"
+        label = duration_label(d, lang)
         keyboard.append([InlineKeyboardButton(label, callback_data=f"sub_{d}")])
     keyboard.append([InlineKeyboardButton(translations["menu_instruction"][lang], callback_data="guide")])
     keyboard.append([InlineKeyboardButton(translations["back"][lang], callback_data="back_to_main")])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,3 +51,8 @@ def test_spoofer_in_games():
     assert 'spoofer' in main.games
     game = main.games['spoofer']
     assert game['durations'] == ['7', '30']
+
+
+def test_duration_label_russian():
+    assert main.duration_label('1', 'ru') == '1 день'
+    assert main.duration_label('7', 'ru') == '7 дней'

--- a/translations.py
+++ b/translations.py
@@ -32,6 +32,22 @@ translations = {
         "tr": "⏳ Abonelik süresini seçin:",
         "ja": "⏳ サブスクリプション期間を選んでください："
     },
+    "day": {
+        "en": "day",
+        "ru": "день",
+        "zh": "天",
+        "ko": "일",
+        "tr": "gün",
+        "ja": "日"
+    },
+    "days": {
+        "en": "days",
+        "ru": "дней",
+        "zh": "天",
+        "ko": "일",
+        "tr": "gün",
+        "ja": "日"
+    },
     "subscription_result": {
         "en": """✅ You selected *{title}* for *{days} days*.
 


### PR DESCRIPTION
## Summary
- include "day"/"days" translations in all languages
- show subscription duration labels in the user language
- test Russian duration labels

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895e3fa59c8323a8b6a7de460c4d37