### PR TITLE
Install python-telegram-bot with job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
    git clone <URL>
    cd telegramBot
    ```
-3. Установите необходимые библиотеки из `requirements.txt`:
+3. Установите необходимые библиотеки из `requirements.txt`.
+   В их числе `python-telegram-bot` с поддержкой `JobQueue`:
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiogram==3.4
+python-telegram-bot[job-queue]==21.1
 python-dotenv==1.0.1
 requests==2.31.0
 pytest==8.4.1


### PR DESCRIPTION
## Summary
- require python-telegram-bot with `JobQueue` support
- clarify README installation step

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a965eaa0083239abd493ab0d5c834