### PR TITLE
Add startup JobQueue check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
    pip install -r requirements.txt
    ```
 
+   Если при запуске вы увидите сообщение об отсутствии `JobQueue`,
+   установите библиотеку с дополнительными возможностями:
+
+   ```bash
+   pip install "python-telegram-bot[job-queue]"
+   ```
+
 ## Настройка `BOT_TOKEN`
 
 Перед запуском необходимо указать токен бота `BOT_TOKEN`, полученный у [BotFather](https://t.me/BotFather).

--- a/main.py
+++ b/main.py
@@ -23,6 +23,11 @@ LOADER_URL = "http://desync.pro:5000/home/download_packed"
 # activity for this amount of seconds. Initially 30 seconds for testing.
 INACTIVITY_SECONDS = 30
 
+JOBQUEUE_ERROR = (
+    "JobQueue is required for inactivity tracking. "
+    'Install extras via `pip install "python-telegram-bot[job-queue]"`.'
+)
+
 user_game_selection: dict[int, str] = {}
 inactivity_jobs: dict[int, object] = {}
 
@@ -59,10 +64,7 @@ def _ensure_job_queue(context: ContextTypes.DEFAULT_TYPE):
     """Return a working job queue or raise a helpful error."""
     job_queue = getattr(context, "job_queue", None)
     if job_queue is None:
-        raise RuntimeError(
-            "JobQueue is required for inactivity tracking. "
-            'Install extras via `pip install "python-telegram-bot[job-queue]"`.'
-        )
+        raise RuntimeError(JOBQUEUE_ERROR)
     return job_queue
 
 
@@ -380,6 +382,8 @@ def main():
         raise RuntimeError("BOT_TOKEN environment variable is not set")
 
     app = Application.builder().token(token).build()
+    if app.job_queue is None:
+        raise RuntimeError(JOBQUEUE_ERROR)
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CallbackQueryHandler(partial(handle_language_selection, show_main_menu_fn=show_main_menu), pattern="^lang_"))
     app.add_handler(CallbackQueryHandler(menu_handler, pattern="^menu_"))


### PR DESCRIPTION
## Summary
- fail fast if JobQueue is missing
- document extra installation for JobQueue

## Testing
- `pytest -q`
- `flake8` *(fails: E501 line too long and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_688a98bb16108323b2fec3d85b1c81ca