### PR TITLE
fix: update telegram library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot[job-queue]==21.1
+python-telegram-bot[job-queue]==21.1.1
 python-dotenv==1.0.1
 requests==2.31.0
 pytest==8.4.1


### PR DESCRIPTION
## Summary
- upgrade python-telegram-bot to 21.1.1 to prevent `_UpdaterType` NameError

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890be182b348323bdc2c89c15e15f3e