### PR TITLE
Migrate to python-telegram-bot 20.7

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from functools import partial
 from dotenv import load_dotenv
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import (
-    Application,
+    ApplicationBuilder,
     CallbackQueryHandler,
     CommandHandler,
     ContextTypes,
@@ -317,7 +317,7 @@ def main():
     if not token:
         raise RuntimeError("BOT_TOKEN environment variable is not set")
 
-    app = Application.builder().token(token).build()
+    app = ApplicationBuilder().token(token).build()
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CallbackQueryHandler(partial(handle_language_selection, show_main_menu_fn=show_main_menu), pattern="^lang_"))
     app.add_handler(CallbackQueryHandler(menu_handler, pattern="^menu_"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot[job-queue]==21.1.1
+python-telegram-bot[job-queue]==20.7
 python-dotenv==1.0.1
 requests==2.31.0
 pytest==8.4.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,7 +15,7 @@ telegram.InlineKeyboardMarkup = object
 telegram.Update = object
 
 telegram_ext = types.ModuleType('telegram.ext')
-telegram_ext.Application = object
+telegram_ext.ApplicationBuilder = object
 telegram_ext.CommandHandler = object
 telegram_ext.CallbackQueryHandler = object
 telegram_ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)


### PR DESCRIPTION
## Summary
- use `ApplicationBuilder` for bot instantiation
- pin python-telegram-bot 20.7
- update tests for ApplicationBuilder stub

## Testing
- `pip install -r requirements.txt`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890bf8ff11083238a63fe39b9f7e28c